### PR TITLE
made output a bit more human friendly and resilient to a bug + also output everything if no property as doc says

### DIFF
--- a/datalad/metadata/search_datasets.py
+++ b/datalad/metadata/search_datasets.py
@@ -52,6 +52,7 @@ class SearchDatasets(Interface):
             doc="""name of the property to report for any match.[CMD:  This
             option can be given multiple times. CMD] If none are given, all
             properties are reported."""),
+        # TODO --json  to output as json
     )
 
     @staticmethod
@@ -62,7 +63,6 @@ class SearchDatasets(Interface):
 
         meta = get_metadata(ds, guess_type=False, ignore_subdatasets=False,
                             ignore_cache=False)
-
         # merge all info on datasets into a single dict per dataset
         lgr.info('Next one is slow, but can be made faster by your contribution!')
         # TODO load offline schema if necessary, cache document load requests
@@ -78,7 +78,7 @@ class SearchDatasets(Interface):
         if not isinstance(meta, list):
             meta = [meta]
 
-        if not isinstance(report, list):
+        if report and not isinstance(report, list):
             report = [report]
 
         expr = re.compile(match)
@@ -100,11 +100,12 @@ class SearchDatasets(Interface):
                     v = unicode(v)
                 hit = hit or expr.match(v)
             if hit:
-                report_dict = {k: mds[k] for k in report if k in mds}
+                report_dict = {k: mds[k] for k in report if k in mds} if report else mds
                 if len(report_dict):
                     yield report_dict
                 else:
-                    lgr.warning('meta data match, but no to-be-reported properties found')
+                    lgr.warning('meta data match, but no to-be-reported properties found. '
+                                'Present properties: %s' % (", ".join(sorted(mds))))
 
     @staticmethod
     def result_renderer_cmdline(res, cmdlineargs):

--- a/datalad/metadata/search_datasets.py
+++ b/datalad/metadata/search_datasets.py
@@ -19,6 +19,7 @@ from datalad.distribution.dataset import datasetmethod, EnsureDataset, \
     require_dataset
 from ..support.param import Parameter
 from ..support.constraints import EnsureNone
+from ..support.constraints import EnsureChoice
 from ..log import lgr
 from . import get_metadata, flatten_metadata_graph
 
@@ -53,12 +54,17 @@ class SearchDatasets(Interface):
             doc="""name of the property to report for any match.[CMD:  This
             option can be given multiple times. CMD] If none are given, all
             properties are reported."""),
-        # TODO --json  to output as json
+        # Theoretically they should be CMDLINE specific I guess?
+        format=Parameter(
+            args=('-f', '--format'),
+            constraints=EnsureChoice('custom', 'json', 'yaml'),
+            doc="""format for output."""
+        )
     )
 
     @staticmethod
     @datasetmethod(name='search_datasets')
-    def __call__(match, dataset, report=None):
+    def __call__(match, dataset, report=None, format='custom'):
 
         ds = require_dataset(dataset, check_installed=True, purpose='dataset search')
 
@@ -113,23 +119,34 @@ class SearchDatasets(Interface):
         from datalad.ui import ui
         if res is None:
             res = []
-        anything = False
-        if cmdlineargs.report is None or len(cmdlineargs.report) > 1:
-            # multiline if multiple were requested and we need to disambiguate
-            ichr = jchr = '\n'
-            fmt = ' {k}: {v}'
-        else:
-            jchr = ', '
-            ichr = ' '
-            fmt = '{v}'
-        for r in res:
-            # XXX Yarik thinks that Match should be replaced with actual path to the dataset
-            ui.message('Match:{}{}'.format(
-                ichr,
-                jchr.join([fmt.format(k=k, v=safe_str(r[k])) for k in sorted(r)])))
-            anything = True
-        if not anything:
-            ui.message("Nothing to report")
+
+        format = cmdlineargs.format or 'custom'
+        if format =='custom':
+            if cmdlineargs.report is None or len(cmdlineargs.report) > 1:
+                # multiline if multiple were requested and we need to disambiguate
+                ichr = jchr = '\n'
+                fmt = ' {k}: {v}'
+            else:
+                jchr = ', '
+                ichr = ' '
+                fmt = '{v}'
+
+            anything = False
+            for r in res:
+                # XXX Yarik thinks that Match should be replaced with actual path to the dataset
+                ui.message('Match:{}{}'.format(
+                    ichr,
+                    jchr.join([fmt.format(k=k, v=safe_str(r[k])) for k in sorted(r)])))
+                anything = True
+            if not anything:
+                ui.message("Nothing to report")
+        elif format == 'json':
+            import json
+            ui.message(json.dumps(list(res), indent=2))
+        elif format == 'yaml':
+            import yaml
+            lgr.warning("yaml output support is not yet polished")
+            ui.message(yaml.safe_dump(list(res), allow_unicode=True, encoding='utf-8'))
 
 def safe_str(s):
     try:

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ requires = {
     'metadata': [
         'simplejson',
         'pyld',
+        'yaml',  # very optional
     ]
 }
 requires['full'] = sum(list(requires.values()), [])


### PR DESCRIPTION
``` shell
(git)smaug:/mnt/scrap/datalad/datasets.datalad.org/openfmri[master]git
$> datalad --dbg search-datasets .*Hanke.* -r name
2016-09-03 21:25:06,216 [INFO   ] Next one is slow, but can be made faster by your contribution! (search_datasets.py:68)
2016-09-03 21:25:16,185 [INFO   ] Fast again... (search_datasets.py:71)
Match: studyforrest_multires7t
Match: studyforrest_phase2

$> datalad --dbg search-datasets .*Hanke.*        
2016-09-03 21:25:24,729 [INFO   ] Next one is slow, but can be made faster by your contribution! (search_datasets.py:68)
2016-09-03 21:25:26,493 [INFO   ] Fast again... (search_datasets.py:71)
Match:
 author: [u'Ayan Sengupta', u'Renat Yakupov', u'Oliver Speck', u'Stefan Pollmann', u'Michael Hanke']
 citation: http://studyforrest.org
 dc:conformsTo: BIDS 1.0.0-rc3
 description: Extension of the dataset published in Hanke et al. (2014; doi:10.1038/sdata.2014.3) with additional acquisitions for 6 of the original 20 participants (and one additional participant). Participants performed a central fixation task while being stimulated with oriented gratings. The experiment was repeated in four different sessions with 7T BOLD fMRI acquisition, each with a different scan resolution (0.8, 1.4, 2.0, and 3.0 mm).
 foaf:fundedBy: This research was supported by a grant from the German Research Foundation (DFG) awarded to S. Pollmann and O. Speck (DFG PO 548/15-1). This research was, in part, also supported by the German Federal Ministry of Education and Research (BMBF) as part of a US-German collaboration in computational neuroscience (CRCNS), co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1112; NSF 1129855). Work on the data-sharing technology employed for this research was supported by US-German CRCNS project, co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1411; NSF 1429999).
 id: 508c35da-7173-11e6-a924-002590f97d84
 license: PDDL
 name: studyforrest_multires7t
 type: Dataset
Match:
 author: [u'Michael Hanke', u'Falko R. Kaule', u'Ayan Sengupta', u'Florian J. Baumgartner', u'J. Swaroop Guntupalli', u'Christian H\xe4usler', u'Michael Hoffmann', u'Vittorio Iacovella', u'Daniel Kottke', u'J\xf6rg Stadler']
 citation: http://studyforrest.org
 dc:conformsTo: BIDS 1.0.0-rc3
 description: Extension of the dataset published in Hanke et al. (2014; doi:10.1038/sdata.2014.3) with additional acquisitions for 15 of the original 20 particpants. These additions include: retinotopic mapping, a localizer paradigm for higher visual areas (FFA, EBA, PPA), and another 2h movie recording with 3T full-brain BOLD fMRI with simultaneous 1000 Hz eyetracking.
 foaf:fundedBy: We acknowledge the support of the Combinatorial NeuroImaging Core Facility at the Leibniz Institute for Neurobiology in Magdeburg, and the German federal state of Saxony-Anhalt, Project: Center for Behavioral Brain Sciences. This research was, in part, also supported by the German Federal Ministry of Education and Research (BMBF) as part of a US-German collaboration in computational neuroscience (CRCNS), co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1112; NSF 1129855). Work on the data-sharing technology employed for this research was supported by US-German CRCNS project, co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1411; NSF 1429999).
 id: 50c39dae-7173-11e6-a924-002590f97d84
 license: PDDL
 name: studyforrest_phase2
 type: Dataset
```

needs `--json` for cmdline anyways to make it properly machine readable

edit1 - I guess `Match:` would eventually get replaced with the dataset path (e.g.`openfmri/ds000001`).
