### PR TITLE
BF: get_toppath

### DIFF
--- a/datalad/crawler/pipeline.py
+++ b/datalad/crawler/pipeline.py
@@ -58,6 +58,7 @@ from ..consts import CRAWLER_META_CONFIG_FILENAME
 from ..utils import updated
 from ..dochelpers import exc_str
 from ..support.gitrepo import GitRepo
+from ..support.annexrepo import AnnexRepo
 from ..support.network import parse_url_opts
 from ..support.stats import ActivityStats
 from ..support.exceptions import PipelineNotSpecifiedError
@@ -412,7 +413,7 @@ def _find_pipeline(name):
             name += '.py'
 
         # first -- current directory
-        repo_path = GitRepo.get_toppath(curdir)
+        repo_path = AnnexRepo.get_toppath(curdir)
         if repo_path:
             yield opj(repo_path, CRAWLER_META_DIR, 'pipelines', name)
 
@@ -530,7 +531,7 @@ def get_repo_pipeline_config_path(repo_path=curdir):
     """Given a path within a repo, return path to the crawl.cfg"""
     if not exists(opj(repo_path, HANDLE_META_DIR)):
         # we need to figure out top path for the repo
-        repo_path = GitRepo.get_toppath(repo_path)
+        repo_path = AnnexRepo.get_toppath(repo_path)
         if not repo_path:
             return None
     return opj(repo_path, CRAWLER_META_CONFIG_PATH)
@@ -542,7 +543,7 @@ def get_repo_pipeline_script_path(repo_path=curdir):
     # tracked or smth like that
     if not exists(opj(repo_path, HANDLE_META_DIR)):
         # we need to figure out top path for the repo
-        repo_path = GitRepo.get_toppath(repo_path)
+        repo_path = AnnexRepo.get_toppath(repo_path)
         if not repo_path:
             return None
     pipelines = glob(opj(repo_path, CRAWLER_META_DIR, 'pipelines', '*.py'))

--- a/datalad/distribution/dataset.py
+++ b/datalad/distribution/dataset.py
@@ -393,7 +393,7 @@ class Dataset(object):
             # normalize the path after adding .. so we guaranteed to not
             # follow into original directory if path itself is a symlink
             par_path = normpath(opj(path, pardir))
-            sds_path_ = GitRepo.get_toppath(par_path)
+            sds_path_ = AnnexRepo.get_toppath(par_path)
             if sds_path_ is None:
                 # no more parents, use previous found
                 break
@@ -574,7 +574,7 @@ def require_dataset(dataset, check_installed=True, purpose=None):
         dataset = Dataset(dataset)
 
     if dataset is None:  # possible scenario of cmdline calls
-        dspath = GitRepo.get_toppath(getpwd())
+        dspath = AnnexRepo.get_toppath(getpwd())
         if not dspath:
             raise NoDatasetArgumentFound("No dataset found")
         dataset = Dataset(dspath)

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -33,7 +33,6 @@ from datalad.support.constraints import EnsureChoice
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
 from datalad.support.param import Parameter
-from datalad.support.gitrepo import GitRepo
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import InsufficientArgumentsError
 from datalad.support.exceptions import IncompleteResultsError
@@ -230,7 +229,7 @@ class Get(Interface):
         # explore the unknown
         for path in sorted(unavailable_paths):
             # how close can we get?
-            dspath = GitRepo.get_toppath(path)
+            dspath = AnnexRepo.get_toppath(path)
             if dspath is None:
                 # nothing we can do for this path
                 continue

--- a/datalad/distribution/tests/test_dataset.py
+++ b/datalad/distribution/tests/test_dataset.py
@@ -272,7 +272,7 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "subsub", "some")).path, subsubds.path)
     # the top of a subdataset belongs to the subdataset
     eq_(ds.get_containing_subdataset(opj("sub", "subsub")).path, subsubds.path)
-    eq_(GitRepo.get_toppath(opj(ds.path, "sub", "subsub")), subsubds.path)
+    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub", "subsub")), subsubds.path)
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     eq_(ds.get_containing_subdataset("some").path, ds.path)
@@ -282,10 +282,10 @@ def test_get_containing_subdataset(path):
     eq_(ds.get_containing_subdataset(opj("sub", "some")).path, subds.path)
     eq_(ds.get_containing_subdataset("sub").path, subds.path)
     # # but now GitRepo disagrees...
-    eq_(GitRepo.get_toppath(opj(ds.path, "sub")), ds.path)
+    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub")), ds.path)
     # and this stays, even if we give the mount point directory back
     os.makedirs(subds.path)
-    eq_(GitRepo.get_toppath(opj(ds.path, "sub")), ds.path)
+    eq_(AnnexRepo.get_toppath(opj(ds.path, "sub")), ds.path)
 
     outside_path = opj(os.pardir, "somewhere", "else")
     assert_raises(PathOutsideRepositoryError, ds.get_containing_subdataset,

--- a/datalad/distribution/uninstall.py
+++ b/datalad/distribution/uninstall.py
@@ -33,7 +33,7 @@ from datalad.interface.utils import path_is_under
 from datalad.interface.utils import save_dataset_hierarchy
 from datalad.interface.utils import _discover_trace_to_known
 from datalad.utils import rmtree
-from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
 
 lgr = logging.getLogger('datalad.distribution.uninstall')
 
@@ -347,7 +347,7 @@ class Remove(Interface):
             # we need to check whether any of these correspond
             # to a known subdataset, and add those to the list of
             # things to be removed
-            toppath = GitRepo.get_toppath(p)
+            toppath = AnnexRepo.get_toppath(p)
             if not toppath:
                 nonexistent_paths.append(p)
                 continue

--- a/datalad/interface/save.py
+++ b/datalad/interface/save.py
@@ -15,7 +15,7 @@ __docformat__ = 'restructuredtext'
 import logging
 from datalad.support.constraints import EnsureStr
 from datalad.support.constraints import EnsureNone
-from datalad.support.gitrepo import GitRepo
+from datalad.support.annexrepo import AnnexRepo
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import Dataset
 from datalad.distribution.dataset import EnsureDataset
@@ -42,7 +42,7 @@ def process_vanished_paths(unavailable_paths, content_by_ds):
         # we need to check whether any of these correspond
         # to a known subdataset, and add those to the list of
         # things to be removed
-        toppath = GitRepo.get_toppath(p)
+        toppath = AnnexRepo.get_toppath(p)
         if not toppath:
             nonexistent_paths.append(p)
             continue

--- a/datalad/interface/utils.py
+++ b/datalad/interface/utils.py
@@ -450,7 +450,7 @@ def untracked_subdatasets_to_submodules(ds, consider_paths):
                          for d in get_dataset_directories(testpath,
                                                           ignore_datalad=True)
                          # do not probe for paths in subdatasets
-                         if GitRepo.get_toppath(testpath) == ds.path])
+                         if AnnexRepo.get_toppath(testpath) == ds.path])
     # the difference are directories that could be an untracked subdataset
     subds_candidates = existing_dirs.difference(indexed_dirs)
     for cand_dspath in subds_candidates:
@@ -521,7 +521,7 @@ def get_paths_by_dataset(paths, recursive=False, recursion_limit=None,
             if not d:
                 d = curdir
         # this could be `None` if there is no git repo
-        dspath = dir_lookup.get(d, GitRepo.get_toppath(d))
+        dspath = dir_lookup.get(d, AnnexRepo.get_toppath(d))
         dir_lookup[d] = dspath
         if not dspath:
             nondataset_paths.append(path)
@@ -661,7 +661,7 @@ def get_dataset_directories(top, ignore_datalad=True):
         names[:] = legit_names
 
     # collects the directories
-    refpath = GitRepo.get_toppath(top)
+    refpath = AnnexRepo.get_toppath(top)
     if not refpath:
         raise ValueError("`top` path {} is not in a dataset".format(top))
     ignore = [opj(refpath, get_git_dir(refpath))]

--- a/datalad/support/annexrepo.py
+++ b/datalad/support/annexrepo.py
@@ -311,6 +311,31 @@ class AnnexRepo(GitRepo):
         return 0 if not exists(fpath) else os.stat(fpath).st_size
 
     @classmethod
+    def get_toppath(cls, path, follow_up=True):
+        """Return top-level of a repository given the path.
+
+        Parameters
+        -----------
+        follow_up : bool
+          If path has symlinks -- they get resolved by git.  If follow_up is
+          True, we will follow original path up until we hit the same resolved
+          path.  If no such path found, resolved one would be returned.
+
+        Return None if no parent directory contains a git repository.
+        """
+
+        # first try plain git result:
+        toppath = GitRepo.get_toppath(path=path, follow_up=follow_up)
+        if toppath == '':
+            # didn't fail, so git itself didn't come to the conclusion
+            # there is no repo, but we have no actual result;
+            # might be an annex in direct mode
+            toppath = GitRepo.get_toppath(path=path, follow_up=follow_up,
+                                          git_options=['-c', 'core.bare=False'])
+
+        return toppath
+
+    @classmethod
     def is_valid_repo(cls, path, allow_noninitialized=False):
         """Return True if given path points to an annex repository"""
         initialized_annex = GitRepo.is_valid_repo(path) and \

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -581,7 +581,7 @@ class GitRepo(object):
             ((not only_remote) and any((b == 'git-annex' for b in self.get_branches())))
 
     @classmethod
-    def get_toppath(cls, path, follow_up=True):
+    def get_toppath(cls, path, follow_up=True, git_options=None):
         """Return top-level of a repository given the path.
 
         Parameters
@@ -590,13 +590,19 @@ class GitRepo(object):
           If path has symlinks -- they get resolved by git.  If follow_up is
           True, we will follow original path up until we hit the same resolved
           path.  If no such path found, resolved one would be returned.
+        git_options: list of str
+          options to be passed to the git rev-parse call
 
         Return None if no parent directory contains a git repository.
         """
+        cmd = ['git']
+        if git_options:
+            cmd.extend(git_options)
+        cmd += ["rev-parse", "--show-toplevel"]
         try:
             with swallow_logs():
                 toppath, err = Runner().run(
-                    ["git", "rev-parse", "--show-toplevel"],
+                    cmd,
                     cwd=path,
                     log_stdout=True, log_stderr=True,
                     expect_fail=True, expect_stderr=True)
@@ -604,7 +610,8 @@ class GitRepo(object):
         except CommandError:
             return None
         except OSError:
-            toppath = GitRepo.get_toppath(dirname(path))
+            toppath = GitRepo.get_toppath(dirname(path), follow_up=follow_up,
+                                          git_options=git_options)
 
         if follow_up:
             path_ = path

--- a/datalad/support/tests/test_annexrepo.py
+++ b/datalad/support/tests/test_annexrepo.py
@@ -1372,3 +1372,22 @@ def test_get_description(path1, path2):
     annex1.merge_annex('annex1')
     annex2.remove_remote('annex1')
     assert_equal(annex2.get_description(uuid=annex1.uuid), annex1_description)
+
+
+@with_testrepos(flavors=local_testrepo_flavors)
+@with_tempfile(mkdir=True)
+@with_tempfile
+def test_AnnexRepo_get_toppath(repo, tempdir, repo2):
+
+    reporeal = realpath(repo)
+    eq_(AnnexRepo.get_toppath(repo, follow_up=False), reporeal)
+    eq_(AnnexRepo.get_toppath(repo), repo)
+    # Generate some nested directory
+    AnnexRepo(repo2, create=True)
+    repo2real = realpath(repo2)
+    nested = opj(repo2, "d1", "d2")
+    os.makedirs(nested)
+    eq_(AnnexRepo.get_toppath(nested, follow_up=False), repo2real)
+    eq_(AnnexRepo.get_toppath(nested), repo2)
+    # and if not under git, should return None
+    eq_(AnnexRepo.get_toppath(tempdir), None)

--- a/datalad/support/tests/test_gitrepo.py
+++ b/datalad/support/tests/test_gitrepo.py
@@ -633,15 +633,18 @@ def test_GitRepo_get_files(url, path):
 
 @with_testrepos(flavors=local_testrepo_flavors)
 @with_tempfile(mkdir=True)
-def test_GitRepo_get_toppath(repo, tempdir):
+@with_tempfile
+def test_GitRepo_get_toppath(repo, tempdir, repo2):
     reporeal = realpath(repo)
     eq_(GitRepo.get_toppath(repo, follow_up=False), reporeal)
     eq_(GitRepo.get_toppath(repo), repo)
     # Generate some nested directory
-    nested = opj(repo, "d1", "d2")
+    GitRepo(repo2, create=True)
+    repo2real = realpath(repo2)
+    nested = opj(repo2, "d1", "d2")
     os.makedirs(nested)
-    eq_(GitRepo.get_toppath(nested, follow_up=False), reporeal)
-    eq_(GitRepo.get_toppath(nested), repo)
+    eq_(GitRepo.get_toppath(nested, follow_up=False), repo2real)
+    eq_(GitRepo.get_toppath(nested), repo2)
     # and if not under git, should return None
     eq_(GitRepo.get_toppath(tempdir), None)
 


### PR DESCRIPTION
Mostly resolves issue https://github.com/datalad/datalad/issues/1179

Note, that `GitRepo.get_toppath()` fails in direct mode, while `AnnexRepo.get_toppath()` doesn't.
Two things left here from my point of view:

- the function has to move, once https://github.com/datalad/datalad/pull/1091 is ready to merge
- still need to figure out why it doesn't work with git 2.11.0 as @mih reported