### PR TITLE
RF: remove some swallowing of the logs, harmonize some install log messages

### DIFF
--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -45,9 +45,6 @@ from .utils import _get_flexible_source_candidates
 from .utils import _handle_possible_annex_dataset
 from .utils import _get_installationpath_from_url
 
-# TODO make this unnecessary
-from datalad.tests.utils import swallow_logs
-
 __docformat__ = 'restructuredtext'
 
 lgr = logging.getLogger('datalad.distribution.clone')
@@ -210,18 +207,14 @@ class Clone(Interface):
             try:
                 lgr.info("Attempting to clone dataset from '%s' to '%s'",
                          source_, dest_path)
-                # TODO this is a shame. we should be able to instruct GitRepo
-                # how to behave wrt logging, and not stick a pillow in its face
-                with swallow_logs():
-                    GitRepo.clone(
-                        path=dest_path, url=source_, create=True)
+                GitRepo.clone(path=dest_path, url=source_, create=True)
                 break  # do not bother with other sources if succeeded
             except GitCommandError as e:
                 lgr.debug("Failed to clone from URL: %s (%s)",
                           source_, exc_str(e))
-                lgr.debug("Wiping out unsuccessful clone attempt at: %s",
-                          dest_path)
                 if exists(dest_path):
+                    lgr.debug("Wiping out unsuccessful clone attempt at: %s",
+                              dest_path)
                     rmtree(dest_path)
 
         if not destination_dataset.is_installed():

--- a/datalad/distribution/clone.py
+++ b/datalad/distribution/clone.py
@@ -203,9 +203,10 @@ class Clone(Interface):
         # generate candidate URLs from source argument to overcome a few corner cases
         # and hopefully be more robust than git clone
         candidate_sources = _get_flexible_source_candidates(source)
+        lgr.info("Cloning dataset from '%s' to '%s'", source, dest_path)
         for source_ in candidate_sources:
             try:
-                lgr.info("Attempting to clone dataset from '%s' to '%s'",
+                lgr.debug("Attempting to clone dataset from '%s' to '%s'",
                          source_, dest_path)
                 GitRepo.clone(path=dest_path, url=source_, create=True)
                 break  # do not bother with other sources if succeeded

--- a/datalad/distribution/get.py
+++ b/datalad/distribution/get.py
@@ -356,9 +356,9 @@ class Get(Interface):
                         continue
                     subds = Dataset(subdspath)
                     lgr.info(
-                        "Obtaining %s %s recursively",
+                        "Installing %s%s recursively",
                         subds,
-                        ("underneath %s" % content_path
+                        (" underneath %s" % content_path
                          if subds.path != content_path
                          else ""))
                     for res in _recursive_install_subds_underneath(

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -318,8 +318,7 @@ def _clone_from_any_source(sources, dest):
         try:
             lgr.debug("Retrieving a dataset from URL: "
                       "{0}".format(source_))
-            with swallow_logs():
-                GitRepo.clone(path=dest, url=source_, create=True)
+            GitRepo.clone(path=dest, url=source_, create=True)
             return source_  # do not bother with other sources if succeeded
         except GitCommandError as e:
             lgr.debug("Failed to retrieve from URL: "
@@ -368,6 +367,11 @@ def _clone_from_any_source(sources, dest):
 
 
 def _handle_possible_annex_dataset(dataset, reckless, description=None):
+    """If dataset "knows annex" -- annex init it, set into reckless etc
+    
+    Provides additional tune up to a possibly an annex repo, e.g.
+    "enables" reckless mode, sets up description
+    """
     # in any case check whether we need to annex-init the installed thing:
     if knows_annex(dataset.path):
         # init annex when traces of a remote annex can be detected

--- a/datalad/distribution/utils.py
+++ b/datalad/distribution/utils.py
@@ -314,10 +314,10 @@ def _clone_from_any_source(sources, dest):
     # of git-clone, due to existing target and an unsuccessful clone
     # attempt. See below.
     existed = dest and exists(dest)
+    lgr.info("Installing dataset %s", dest)
     for source_ in sources:
         try:
-            lgr.debug("Retrieving a dataset from URL: "
-                      "{0}".format(source_))
+            lgr.debug("Attempting to clone {0}".format(source_))
             GitRepo.clone(path=dest, url=source_, create=True)
             return source_  # do not bother with other sources if succeeded
         except GitCommandError as e:

--- a/datalad/support/gitrepo.py
+++ b/datalad/support/gitrepo.py
@@ -558,12 +558,16 @@ class GitRepo(RepoInterface):
         ----------
         url : str
         path : str
+        expect_fail : bool
+          Either expect that command might fail, so error should be logged then
+          at DEBUG level instead of ERROR
         """
 
         if 'repo' in kwargs:
             raise TypeError("argument 'repo' conflicts with cloning")
             # TODO: what about 'create'?
 
+        expect_fail = kwargs.pop('expect_fail', False)
         # fail early on non-empty target:
         from os import listdir
         if exists(path) and listdir(path):
@@ -623,7 +627,7 @@ class GitRepo(RepoInterface):
                         "retrying",
                         trial)
                     continue
-                lgr.error(e_str)
+                    (lgr.debug if expect_fail else lgr.error)(e_str)
                 raise
             except ValueError as e:
                 if gitpy.__version__ == '1.0.2' \


### PR DESCRIPTION
- we should be providing some logs while installing recursively instead of just staying silent
- at some point should harmonize log messages even more -- it was 'obtaining', 'retrieving' ... replaced with 'Installing'