### PR TITLE
ENH: make tools/rec_asciinema usable by others, add color to the path in the prompt

### DIFF
--- a/tools/rec_asciinema
+++ b/tools/rec_asciinema
@@ -75,7 +75,8 @@ function run_expfail () {
 cmds_log="$title.cmds"
 rm -f "$cmds_log"
 echo "Recording to $(readlink -f "$title.json") with commands log in $cmds_log"
-type "asciinema rec \"$title.json\" -c 'bash --rcfile tools/screencast_bash.rc' -w 2"
+bashrc_file="$(dirname $0)/screencast_bash.rc"
+type "asciinema rec \"$title.json\" -c 'bash --rcfile $bashrc_file' -w 2"
 # XXX cannot use execute here, idle detection not yet functional
 key Return
 sleep 1.0
@@ -98,3 +99,7 @@ while test -d "/proc/$asciinema_pid"; do sleep 1; echo "wait for asciinema"; don
 
 # kill the xterm we opened
 kill $xterm_pid
+
+# adjust title if was specified
+full_title=${full_title:-$title}
+sed -i -e "s/^\( *.command.\): \".*/\1: \"$full_title\",/" "$title.json"

--- a/tools/rec_asciinema
+++ b/tools/rec_asciinema
@@ -17,16 +17,29 @@ xterm_pid=$!
 sleep 1
 $xdt --sync sleep 0.5
 
+function check_asciinema () {
+    if [ ! -z "${asciinema_pid:-}" ] && [ ! -e "/proc/$asciinema_pid" ]; then
+        echo "Asciinema stopped unexpectedly. Exiting. Check output in the xterm" >&2
+        # Do not kill xterm so we could see what went wrong!
+        ## [ -z "${xterm_pid:-}" ] || kill $xterm_pid
+        exit 1
+    fi
+}
+
 function type () {
+    check_asciinema
 	$xdt type --clearmodifiers --delay 40 --window %@ "$1"
 }
 function key () {
+    check_asciinema
 	$xdt key --clearmodifiers --window %@ $*
 }
 function sleep () {
+    check_asciinema
 	xdotool sleep $1
 }
 function execute () {
+    check_asciinema
 	$xdt sleep 0.5 key --window %@ Return sleep 0.5
 	while [ x"$xterm_pstree" != x"$(pstree -p $xterm_pid)" ]; do
 		sleep 0.5
@@ -39,6 +52,7 @@ function say()
 	sleep 3
 }
 function show () {
+    check_asciinema
 	$xdt type --clearmodifiers --delay 0 --window %@ "$(printf "\n$1\n\n" | sed -e 's/^/# /g')"
 	key Return
 	sleep 3

--- a/tools/rec_asciinema
+++ b/tools/rec_asciinema
@@ -40,9 +40,9 @@ function sleep () {
 }
 function execute () {
     check_asciinema
-	$xdt sleep 0.5 key --window %@ Return sleep 0.5
+	$xdt sleep 0.5 key --window %@ Return
 	while [ x"$xterm_pstree" != x"$(pstree -p $xterm_pid)" ]; do
-		sleep 0.5
+		sleep 0.01
 	done
 }
 function say()
@@ -53,21 +53,28 @@ function say()
 }
 function show () {
     check_asciinema
-	$xdt type --clearmodifiers --delay 0 --window %@ "$(printf "\n$1\n\n" | sed -e 's/^/# /g')"
-	key Return
-	sleep 3
+    $xdt type --clearmodifiers --delay 0 --window %@ "$(printf "\n$1\n\n" | sed -e 's/^/# /g')"
+    key Return
+    sleep 3
 }
 function run () {
-	type "$1"
-	execute
-	sleep 2
+    type "$1"
+    t1=$(date +%s.%N)
+    execute
+    t2=$(date +%s.%N)
+    # Subtracting 0.5 imposed by execute before hitting Return
+    dt=$(printf "%.2f" `echo "$t2 - $t1 - 0.5" | bc`)
+    echo "$@" "    # $dt sec" >> "$cmds_log"
+    sleep 2
 }
 function run_expfail () {
 	# TODO we could announce or visualize the expected failure
 	run "$1"
 }
 
-echo "Recording to $(readlink -f "$title.json")"
+cmds_log="$title.cmds"
+rm -f "$cmds_log"
+echo "Recording to $(readlink -f "$title.json") with commands log in $cmds_log"
 type "asciinema rec \"$title.json\" -c 'bash --rcfile tools/screencast_bash.rc' -w 2"
 # XXX cannot use execute here, idle detection not yet functional
 key Return

--- a/tools/screencast_bash.rc
+++ b/tools/screencast_bash.rc
@@ -32,8 +32,13 @@ export PS3=
 export PS4=+
 
 # make a fake temporary home dir and go into it
-SCREENCAST_HOME=${SCREENCAST_HOME:-/tmp/datalad-demo}
-mkdir -p "$SCREENCAST_HOME"
+SCREENCAST_HOME=${SCREENCAST_HOME:-/demo}
+if [ ! -e "$SCREENCAST_HOME" ]; then
+    mkdir -p ${SCREENCAST_HOME} || {
+        echo "FAILED to create $SCREENCAST_HOME" >&2
+        exit 1;  # we need demo directory!
+    }
+fi
 HOME=$SCREENCAST_HOME
 export HOME
 cd

--- a/tools/screencast_bash.rc
+++ b/tools/screencast_bash.rc
@@ -1,14 +1,49 @@
-# we need a compact prompt to maximize use of the small terminal
-PS1='\w % '
+#emacs: -*- mode: shell-script; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+#ex: set sts=4 ts=4 sw=4 et:
+# This file contains bash configuration variables to be used for generating
+# asciinema demos to guarantee consistent appearance.
+
+: ${do_colors:=1}
+
+if [ ! -z "$do_colors" ]; then
+    # Lets color PSes
+    black='\[\e[0;30m\]'
+    Black='\[\e[1;30m\]'
+    red='\[\e[0;31m\]'
+    Red='\[\e[1;31m\]'
+    green='\[\e[0;32m\]'
+    Green='\[\e[1;32m\]'
+    yellow='\[\e[0;33m\]'
+    Yellow='\[\e[1;33m\]'
+    blue='\[\e[0;34m\]'
+    Blue='\[\e[1;34m\]'
+    cyan='\[\e[0;36m\]'
+    Cyan='\[\e[1;36m\]'
+    white='\[\e[0;37m\]'
+    White='\[\e[1;37m\]'
+    NC='\[\e[0m\]' #no color
+fi
+
+# Color the working directory to help highlighting boundaries of the commands
+# execution/output
+export PS1="${Cyan}\w${NC} % "
+export PS2="> "
+export PS3=
+export PS4=+
 
 # make a fake temporary home dir and go into it
-SCREENCAST_HOME=/demo
+SCREENCAST_HOME=${SCREENCAST_HOME:-/tmp/datalad-demo}
+mkdir -p "$SCREENCAST_HOME"
 HOME=$SCREENCAST_HOME
 export HOME
 cd
 
-export PATH=~/datalad/bin:$PATH
-export PYTHONPATH=~/datalad
+if ! hash datalad; then
+    # assume layout of the "master" but should be working fine if datalad
+    # is system wide or virtualenv installed in the session
+    export PATH=~/datalad/bin:$PATH
+    export PYTHONPATH=~/datalad
+fi
 
 # Basic git setup
 git config --global user.name "Datalad Demo"


### PR DESCRIPTION
- added coloring to the path, so it is easier to see the boundaries of the commands execution
- I have neither `/demo`, nor `~/datalad` repository.  `datalad` command is just available (virtualenv).