### PR TITLE
BF: removed rogue set() call, avoid overloading "k" within a comprehension

### DIFF
--- a/datalad/metadata/search.py
+++ b/datalad/metadata/search.py
@@ -181,15 +181,14 @@ def _get_search_schema(ds):
                 # might be different when some aggregated metadata was
                 # generated with an old version of datalad
                 # in this case we should actually load the old vocabulary
-                set.add(', '.join(i for i in v) if isinstance(v, (tuple, list)) else v)
+                #set.add(', '.join(i for i in v) if isinstance(v, (tuple, list)) else v)
                 # and perform the mapping to the current one in here
                 count = 0
                 uk = k
                 while uk in definitions:
                     count += 1
                     uk = '{}_{}'.format(k, count)
-                ds_defs[k] = uk
-                k = uk
+                ds_defs[k] = k = uk
             definitions[k] = v
             # we register a field for any definition in the context.
             # while this has the potential to needlessly blow up the
@@ -227,12 +226,14 @@ def _get_search_schema(ds):
                 schema_fields[k] = wf.TEXT(stored=True)
             else:
                 if isinstance(definitions[k], dict):
-                    definitions[k] = \
-                        {k if k == '@id' else '{} ({})'.format(
-                            k,
-                            _resolve_term(k, definitions, common_defs)) :
-                         _resolve_term(v, definitions, common_defs)
-                         for k, v in definitions[k].items()}
+                    definitions[k] = {
+                        k_ if k_ == '@id' else '{} ({})'.format(
+                           k_,
+                           _resolve_term(k_, definitions, common_defs))
+                        : _resolve_term(v, definitions, common_defs)
+                        for k_, v in definitions[k].items()
+                        if v  # skip if value is empty
+                    }
 
     schema = wf.Schema(**schema_fields)
     return schema, definitions, per_ds_defs


### PR DESCRIPTION
Was trying to address https://github.com/datalad/datalad/issues/1903 ... current state of affairs:
```shell
(git)smaug:/mnt/btrfs/scrap/datalad/tmp/datasets[master]git
$> datalad --dbg search *nwb*
[INFO   ] Rebuilding search index
[INFO   ] Scanning for metadata keys
Traceback (most recent call last):
  File "/home/yoh/proj/datalad/datalad/venvs/dev/bin/datalad", line 8, in <module>
    main()
  File "/home/yoh/proj/datalad/datalad/datalad/cmdline/main.py", line 347, in main
    ret = cmdlineargs.func(cmdlineargs)
  File "/home/yoh/proj/datalad/datalad/datalad/interface/base.py", line 427, in call_from_parser
    ret = list(ret)
  File "/home/yoh/proj/datalad/datalad/datalad/interface/utils.py", line 382, in generator_func
    result_renderer, result_xfm, _result_filter, **_kwargs):
  File "/home/yoh/proj/datalad/datalad/datalad/interface/utils.py", line 449, in _process_results
    for res in results:
  File "/home/yoh/proj/datalad/datalad/datalad/metadata/search.py", line 572, in __call__
    index_dir, ds, force_reindex)
  File "/home/yoh/proj/datalad/datalad/datalad/metadata/search.py", line 291, in _get_search_index
    schema, definitions, per_ds_defs = _get_search_schema(ds)
  File "/home/yoh/proj/datalad/datalad/datalad/metadata/search.py", line 238, in _get_search_schema
    schema = wf.Schema(**schema_fields)
  File "/usr/lib/python2.7/dist-packages/whoosh/fields.py", line 1344, in __init__
    self.add(name, fields[name])
  File "/usr/lib/python2.7/dist-packages/whoosh/fields.py", line 1481, in add
    raise FieldConfigurationError("Names cannot contain spaces")
FieldConfigurationError: Names cannot contain spaces
()
> /usr/lib/python2.7/dist-packages/whoosh/fields.py(1481)add()
-> raise FieldConfigurationError("Names cannot contain spaces")
(Pdb) up
> /usr/lib/python2.7/dist-packages/whoosh/fields.py(1344)__init__()
-> self.add(name, fields[name])
(Pdb) p name
u'comment<% analgesia womac>'

```